### PR TITLE
Settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/Fields/TextField/textfield.h widgets/editor/Fields/TextField/textfield.cpp widgets/editor/Fields/TextField/textfield.ui
         widgets/editor/FieldConnection/fieldconnection.h widgets/editor/FieldConnection/fieldconnection.cpp widgets/editor/FieldConnection/fieldconnection.ui
         widgets/editor/Fields/CharacterField/characterfield.h widgets/editor/Fields/CharacterField/characterfield.cpp widgets/editor/Fields/CharacterField/characterfield.ui
+
         widgets/editor/EditorTools/Settings/listsettings.h widgets/editor/EditorTools/Settings/listsettings.cpp
         widgets/editor/EditorTools/Settings/effectsettings.h widgets/editor/EditorTools/Settings/effectsettings.cpp
         widgets/editor/EditorTools/Settings/presetsettings.h widgets/editor/EditorTools/Settings/presetsettings.cpp
@@ -61,7 +62,9 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/EditorTools/Settings/presetsettings.ui
         widgets/editor/EditorTools/Settings/listsettings.ui
         widgets/editor/EditorTools/Settings/settingsoption.h widgets/editor/EditorTools/Settings/settingsoption.cpp widgets/editor/EditorTools/Settings/settingsoption.ui
+
         widgets/editor/Fields/ListField/listfield.h widgets/editor/Fields/ListField/listfield.cpp widgets/editor/Fields/ListField/listfield.ui
+
         widgets/editor/EditorTools/EffectsDropdown/effectsdropdown.h widgets/editor/EditorTools/EffectsDropdown/effectsdropdown.cpp widgets/editor/EditorTools/EffectsDropdown/effectsdropdown.ui
 
         data/Presets/preset.h data/Presets/preset.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/EditorTools/Settings/presetsettings.ui
         widgets/editor/EditorTools/Settings/listsettings.ui
         widgets/editor/EditorTools/Settings/settingsoption.h widgets/editor/EditorTools/Settings/settingsoption.cpp widgets/editor/EditorTools/Settings/settingsoption.ui
+        widgets/editor/Fields/ListField/listfield.h widgets/editor/Fields/ListField/listfield.cpp widgets/editor/Fields/ListField/listfield.ui
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/Fields/TextField/textfield.h widgets/editor/Fields/TextField/textfield.cpp widgets/editor/Fields/TextField/textfield.ui
         widgets/editor/FieldConnection/fieldconnection.h widgets/editor/FieldConnection/fieldconnection.cpp widgets/editor/FieldConnection/fieldconnection.ui
         widgets/editor/Fields/CharacterField/characterfield.h widgets/editor/Fields/CharacterField/characterfield.cpp widgets/editor/Fields/CharacterField/characterfield.ui
+        widgets/editor/EditorTools/Settings/listsettings.h widgets/editor/EditorTools/Settings/listsettings.cpp
+        widgets/editor/EditorTools/Settings/effectsettings.h widgets/editor/EditorTools/Settings/effectsettings.cpp
+        widgets/editor/EditorTools/Settings/presetsettings.h widgets/editor/EditorTools/Settings/presetsettings.cpp
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/EditorTools/Settings/effectsettings.ui
         widgets/editor/EditorTools/Settings/presetsettings.ui
         widgets/editor/EditorTools/Settings/listsettings.ui
+        widgets/editor/EditorTools/Settings/settingsoption.h widgets/editor/EditorTools/Settings/settingsoption.cpp widgets/editor/EditorTools/Settings/settingsoption.ui
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         widgets/editor/EditorTools/Settings/listsettings.h widgets/editor/EditorTools/Settings/listsettings.cpp
         widgets/editor/EditorTools/Settings/effectsettings.h widgets/editor/EditorTools/Settings/effectsettings.cpp
         widgets/editor/EditorTools/Settings/presetsettings.h widgets/editor/EditorTools/Settings/presetsettings.cpp
+        widgets/editor/EditorTools/Settings/effectsettings.ui
+        widgets/editor/EditorTools/Settings/presetsettings.ui
+        widgets/editor/EditorTools/Settings/listsettings.ui
 
 
 

--- a/data/Fields/MainFields/input/inputdata.cpp
+++ b/data/Fields/MainFields/input/inputdata.cpp
@@ -7,3 +7,9 @@ InputData::InputData(QWidget* ui, ConnectionData* fromConnection, ConnectionData
 {
 
 }
+
+
+const int InputData::getID()
+{
+    return 3;
+}

--- a/data/Fields/MainFields/input/inputdata.h
+++ b/data/Fields/MainFields/input/inputdata.h
@@ -18,6 +18,7 @@ class InputData : protected MainFieldData
 {
 public:
     InputData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* toConnection);
+    const int getID() override;
 };
 
 #endif // INPUTDATA_H

--- a/data/Fields/MainFields/list/listdata.cpp
+++ b/data/Fields/MainFields/list/listdata.cpp
@@ -4,10 +4,13 @@
 #include <qDebug>
 
 #include "../mainfielddata.h"
-
+#include "widgets/editor/Fields/ListField/listfield.h"
 
 ListData::ListData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* toConnection, string txt, string delim) : MainFieldData(ui, fromConnection, toConnection)
 {
+    ListField* field = reinterpret_cast <ListField*>(ui);
+    field->setData(this);
+
     this->text = txt;
     this->delimiter = delim;
     this->indecies = list<pair<int, int>>();
@@ -16,6 +19,8 @@ ListData::ListData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* 
 
 ListData::ListData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* toConnection) : MainFieldData(ui, fromConnection, toConnection)
 {
+    ListField* field = reinterpret_cast <ListField*>(ui);
+    field->setData(this);
 }
 
 void ListData::setText(string txt)
@@ -23,11 +28,18 @@ void ListData::setText(string txt)
     this->text = txt;
     generateIndecies();
 }
-void ListData::setDelimiter(string delim)
+void ListData::setDelimiter(string delim = baseDelimiter)
 {
     this->delimiter = delim;
     generateIndecies();
 }
+void ListData::setDelimiterAndText(string delim = baseDelimiter, string txt = "")
+{
+    this->text = txt;
+    this->delimiter = delim;
+    generateIndecies();
+}
+
 void ListData::generateIndecies()
 {
     indecies = list<pair<int,int>>();
@@ -214,4 +226,9 @@ void ListData::print()
         qDebug() << p << " " << getText().substr(p.first, p.second) <<" " <<count << "\n";
         count++;
     }
+}
+
+const int ListData::getID()
+{
+    return 2;
 }

--- a/data/Fields/MainFields/list/listdata.h
+++ b/data/Fields/MainFields/list/listdata.h
@@ -27,6 +27,7 @@ public:
     // setters
     void setDelimiter (string delim);
     void setText (string txt);
+    void setDelimiterAndText(string delim, string txt);
     // modifiers
     void push_back(string s);
     void push_front(string s);
@@ -38,6 +39,7 @@ public:
     list<string> toList();
     list<pair<int,int>> getIndecies();
     void print();
+    const int getID() override;
 private:
     string delimiter;
     // <startLocation, length>

--- a/data/Fields/MainFields/text/textdata.cpp
+++ b/data/Fields/MainFields/text/textdata.cpp
@@ -11,3 +11,8 @@ TextData::TextData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* 
     field->setData(this);
 
 }
+
+const int TextData::getID()
+{
+    return 1;
+}

--- a/data/Fields/MainFields/text/textdata.h
+++ b/data/Fields/MainFields/text/textdata.h
@@ -16,6 +16,7 @@ public:
     TextData(QWidget* ui, ConnectionData* fromConnection, ConnectionData* toConnection);
     // deconstructor
     ~TextData();
+    const int getID() override;
 
 };
 #endif // TEXTDATA_H

--- a/data/Fields/fielddata.cpp
+++ b/data/Fields/fielddata.cpp
@@ -171,3 +171,8 @@ void FieldData::removeAll() {
 
     delete this;
 }
+
+const int FieldData::getID()
+{
+    return 0;
+}

--- a/data/Fields/fielddata.h
+++ b/data/Fields/fielddata.h
@@ -23,6 +23,11 @@ public:
     ~FieldData();
     // accessors
     const string getText();
+    /**
+     * @brief getID
+     * @return the id of the FieldData type
+     */
+    const virtual int getID();
     // setters
     void setText(string newText);
     // Field effect functions

--- a/widgets/editor/Designer/designer.cpp
+++ b/widgets/editor/Designer/designer.cpp
@@ -3,6 +3,7 @@
 
 #include "../Fields/TextField/textfield.h"
 #include "../FieldConnection/fieldConnection.h"
+#include "../Fields/ListField/listfield.h"
 
 Designer::Designer(QWidget *parent) :
     QWidget(parent),
@@ -28,6 +29,13 @@ TextField* Designer::createTextField() {
 
     ui->fieldContainer->addWidget(textField);
     return textField;
+}
+
+ListField* Designer::createListField() {
+    ListField* listField = new ListField();
+
+    ui->fieldContainer->addWidget(listField);
+    return listField;
 }
 
 void Designer::removeWidget(QWidget* widget) {

--- a/widgets/editor/Designer/designer.h
+++ b/widgets/editor/Designer/designer.h
@@ -7,6 +7,7 @@
 
 class FieldConnection;
 class TextField;
+class ListField;
 
 namespace Ui {
 class Designer;
@@ -22,6 +23,7 @@ public:
 
     FieldConnection* createFieldConnection();
     TextField* createTextField();
+    ListField* createListField();
 
     void removeWidget(QWidget* widget);
 

--- a/widgets/editor/EditorTools/Settings/effectsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/effectsettings.cpp
@@ -1,0 +1,6 @@
+#include "effectsettings.h"
+
+EffectSettings::EffectSettings()
+{
+
+}

--- a/widgets/editor/EditorTools/Settings/effectsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/effectsettings.cpp
@@ -1,6 +1,15 @@
 #include "effectsettings.h"
+#include "ui_effectsettings.h"
 
-EffectSettings::EffectSettings()
+EffectSettings::EffectSettings(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::EffectSettings)
 {
-
+    ui->setupUi(this);
 }
+
+EffectSettings::~EffectSettings()
+{
+    delete ui;
+}
+

--- a/widgets/editor/EditorTools/Settings/effectsettings.h
+++ b/widgets/editor/EditorTools/Settings/effectsettings.h
@@ -13,10 +13,11 @@ class EffectSettings : public QDialog
     Q_OBJECT
 
 public:
+    // constructor and destructor
     explicit EffectSettings(QWidget *parent = nullptr);
     ~EffectSettings();
 
-    // Buttons
+    // buttons
     QPushButton* getOK();
     QPushButton* getCancel();
 

--- a/widgets/editor/EditorTools/Settings/effectsettings.h
+++ b/widgets/editor/EditorTools/Settings/effectsettings.h
@@ -1,0 +1,11 @@
+#ifndef EFFECTSETTINGS_H
+#define EFFECTSETTINGS_H
+
+
+class EffectSettings
+{
+public:
+    EffectSettings();
+};
+
+#endif // EFFECTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/effectsettings.h
+++ b/widgets/editor/EditorTools/Settings/effectsettings.h
@@ -1,11 +1,31 @@
 #ifndef EFFECTSETTINGS_H
 #define EFFECTSETTINGS_H
 
+#include <QPushButton>
+#include <QDialog>
 
-class EffectSettings
+namespace Ui {
+class EffectSettings;
+}
+
+class EffectSettings : public QDialog
 {
+    Q_OBJECT
+
 public:
-    EffectSettings();
+    explicit EffectSettings(QWidget *parent = nullptr);
+    ~EffectSettings();
+
+    // Buttons
+    QPushButton* getOK();
+    QPushButton* getCancel();
+
+signals:
+
+private slots:
+
+private:
+    Ui::EffectSettings *ui;
 };
 
 #endif // EFFECTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/effectsettings.ui
+++ b/widgets/editor/EditorTools/Settings/effectsettings.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EffectSettings</class>
+ <widget class="QDialog" name="EffectSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>EffectSettings</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>EffectSettings</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -12,6 +12,7 @@ ListSettings::ListSettings(QWidget *parent) :
     listElements = new list<SettingsOption*>();
     connect(ui->Add, &QAbstractButton::clicked, this, &ListSettings::addOption);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ListSettings::saveOptions);
+    connect(this, &ListSettings::optionErased, this, &ListSettings::eraseOption);
 }
 
 ListSettings::~ListSettings()
@@ -22,34 +23,28 @@ ListSettings::~ListSettings()
     //delete[] listElements;
 }
 
-
-
 void ListSettings::addOption()
 {
-    SettingsOption* qLine = new  SettingsOption(ui->listView);
-    listElements->push_back(qLine);
-    qLine->show();
-    connect(qLine->getButton(), &QPushButton::clicked, this, &ListSettings::optionErased);
+    SettingsOption* option = new  SettingsOption(ui->listView, listElements->size(), this);
+    listElements->push_back(option);
+    option->show();
+    connect(option->getButton(), &QPushButton::clicked, option, &SettingsOption::erase);
 }
-
-
-
-
 
 void ListSettings::eraseOption(int index)
 {
-    list<string>::iterator itr = data->begin();
-    list<SettingsOption*>::iterator itr2 = listElements->begin();
+    qDebug() << "Index: " << index;
+
+    list<SettingsOption*>::iterator itr = listElements->begin();
     for(int i = 0; i < index; i++)
     {
-        itr++;
-        itr2++;
+        ++itr;
     }
     // Delete the UI element
-    delete (*itr2);
+    (*itr)->deleteLater();
     // Wipe the element and string from their lists
-    listElements->erase(itr2);
-    data->erase(itr);
+    listElements->erase(itr);
+
 }
 
 void ListSettings::loadOptions()
@@ -76,12 +71,9 @@ void ListSettings::loadOptions()
 
 void ListSettings::saveOptions()
 {
+    data->clear();
     for(SettingsOption* element : (*listElements))
     {
         data->push_back(element->getLineEdit()->text().toStdString());
     }
-    /*for (SettingsOption* option : *listElements) {
-        emit saveSettings(option);
-    }
-    */
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -2,13 +2,15 @@
 #include <QLineEdit>
 #include "ui_listsettings.h"
 
+
 ListSettings::ListSettings(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ListSettings)
 {
     ui->setupUi(this);
     data = new list<string>();
-    listElements = new list<QLineEdit*>();
+    listElements = new list<SettingsOption*>();
+    connect(ui->Add, &QAbstractButton::clicked, this, &ListSettings::addOption);
 }
 
 ListSettings::~ListSettings()
@@ -19,16 +21,18 @@ ListSettings::~ListSettings()
     //delete[] listElements;
 }
 
+
+
 void ListSettings::addOption()
 {
-    QLineEdit* qLine = new QLineEdit("OPTION", ui->listView);
+    SettingsOption* qLine = new  SettingsOption(ui->listView);
     listElements->push_back(qLine);
     qLine->show();
 }
 void ListSettings::eraseOption(int index)
 {
     list<string>::iterator itr = data->begin();
-    list<QLineEdit*>::iterator itr2 = listElements->begin();
+    list<SettingsOption*>::iterator itr2 = listElements->begin();
     for(int i = 0; i < index; i++)
     {
         itr++;
@@ -53,20 +57,21 @@ void ListSettings::loadOptions()
         }
     }
     list<string>::iterator itr = data->begin();
-    list<QLineEdit*>::iterator itr2 = listElements->begin();
+    list<SettingsOption*>::iterator itr2 = listElements->begin();
     // fill in the text
     for(int i = 0; i < data->size(); i++)
     {
-        (*itr2)->setText(QString::fromStdString(*itr));
+        (*itr2)->getLineEdit()->setText(QString::fromStdString(*itr));
         itr++;
         itr2++;
     }
+
 }
 
 void ListSettings::saveOptions()
 {
-    for(QLineEdit* element : (*listElements))
+    for(SettingsOption* element : (*listElements))
     {
-        data->push_back(element->text().toStdString());
+        data->push_back(element->getLineEdit()->text().toStdString());
     }
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -1,6 +1,15 @@
 #include "listsettings.h"
 
-listsettings::listsettings()
-{
+#include "ui_listsettings.h"
 
+ListSettings::ListSettings(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ListSettings)
+{
+    ui->setupUi(this);
+}
+
+ListSettings::~ListSettings()
+{
+    delete ui;
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -25,9 +25,10 @@ ListSettings::~ListSettings()
 
 void ListSettings::addOption()
 {
-    SettingsOption* option = new  SettingsOption(ui->listView, listElements->size(), this);
-    listElements->push_back(option);
+    SettingsOption* option = new SettingsOption(nullptr, listElements->size(), this);
+    ui->verticalLayoutWidget->layout()->addWidget(option);
     option->show();
+    listElements->push_back(option);
     connect(option->getButton(), &QPushButton::clicked, option, &SettingsOption::erase);
 }
 
@@ -44,7 +45,12 @@ void ListSettings::eraseOption(int index)
     (*itr)->deleteLater();
     // Wipe the element and string from their lists
     listElements->erase(itr);
-
+    int count = 0;
+    for(SettingsOption* option : (*listElements))
+    {
+        option->setIndex(count);
+        count++;
+    }
 }
 
 void ListSettings::loadOptions()

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -2,6 +2,8 @@
 #include <QLineEdit>
 #include "ui_listsettings.h"
 #include <QDialogButtonBox>
+#include <data/Fields/MainFields/list/listdata.h>
+#include <widgets/editor/MainEditor/maineditor.h>
 
 ListSettings::ListSettings(QWidget *parent) :
     QDialog(parent),
@@ -55,14 +57,16 @@ void ListSettings::eraseOption(int index)
 
 void ListSettings::loadOptions()
 {
-    // add missing ui elements if there are any
-    int difference = data->size()-listElements->size();
-    if (difference > 0)
+    // remove the options
+    for (SettingsOption* option : *(listElements))
     {
-        for (int i = 0; i < difference; i++)
-        {
-            addOption();
-        }
+        option->deleteLater();
+    }
+    listElements->clear();
+    // re-add the options
+    for (int i = 0; i <  data->size(); i++)
+    {
+        addOption();
     }
     list<string>::iterator itr = data->begin();
     list<SettingsOption*>::iterator itr2 = listElements->begin();
@@ -70,16 +74,25 @@ void ListSettings::loadOptions()
     for(int i = 0; i < data->size(); i++)
     {
         (*itr2)->getLineEdit()->setText(QString::fromStdString(*itr));
-        itr++;
         itr2++;
+        itr++;
     }
 }
 
 void ListSettings::saveOptions()
 {
+    qDebug() << "ListSettings: Saving Options";
     data->clear();
     for(SettingsOption* element : (*listElements))
     {
         data->push_back(element->getLineEdit()->text().toStdString());
     }
+    // pack the options
+    string txt = "";
+    for(string s : *(data))
+    {
+        txt += baseDelimiter + s;
+    }
+    // send the options off
+    emit optionsSaved(txt);
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -1,5 +1,5 @@
 #include "listsettings.h"
-
+#include <QLineEdit>
 #include "ui_listsettings.h"
 
 ListSettings::ListSettings(QWidget *parent) :
@@ -7,9 +7,66 @@ ListSettings::ListSettings(QWidget *parent) :
     ui(new Ui::ListSettings)
 {
     ui->setupUi(this);
+    data = new list<string>();
+    listElements = new list<QLineEdit*>();
 }
 
 ListSettings::~ListSettings()
 {
     delete ui;
+    delete[] data;
+    // don't delete listElements because they are parented to EditorTools
+    //delete[] listElements;
+}
+
+void ListSettings::addOption()
+{
+    QLineEdit* qLine = new QLineEdit("OPTION", ui->listView);
+    listElements->push_back(qLine);
+    qLine->show();
+}
+void ListSettings::eraseOption(int index)
+{
+    list<string>::iterator itr = data->begin();
+    list<QLineEdit*>::iterator itr2 = listElements->begin();
+    for(int i = 0; i < index; i++)
+    {
+        itr++;
+        itr2++;
+    }
+    // Delete the UI element
+    delete (*itr2);
+    // Wipe the element and string from their lists
+    listElements->erase(itr2);
+    data->erase(itr);
+}
+
+void ListSettings::loadOptions()
+{
+    // add missing ui elements if there are any
+    int difference = data->size()-listElements->size();
+    if (difference > 0)
+    {
+        for (int i = 0; i < difference; i++)
+        {
+            addOption();
+        }
+    }
+    list<string>::iterator itr = data->begin();
+    list<QLineEdit*>::iterator itr2 = listElements->begin();
+    // fill in the text
+    for(int i = 0; i < data->size(); i++)
+    {
+        (*itr2)->setText(QString::fromStdString(*itr));
+        itr++;
+        itr2++;
+    }
+}
+
+void ListSettings::saveOptions()
+{
+    for(QLineEdit* element : (*listElements))
+    {
+        data->push_back(element->text().toStdString());
+    }
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -1,0 +1,6 @@
+#include "listsettings.h"
+
+listsettings::listsettings()
+{
+
+}

--- a/widgets/editor/EditorTools/Settings/listsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/listsettings.cpp
@@ -1,7 +1,7 @@
 #include "listsettings.h"
 #include <QLineEdit>
 #include "ui_listsettings.h"
-
+#include <QDialogButtonBox>
 
 ListSettings::ListSettings(QWidget *parent) :
     QDialog(parent),
@@ -11,6 +11,7 @@ ListSettings::ListSettings(QWidget *parent) :
     data = new list<string>();
     listElements = new list<SettingsOption*>();
     connect(ui->Add, &QAbstractButton::clicked, this, &ListSettings::addOption);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ListSettings::saveOptions);
 }
 
 ListSettings::~ListSettings()
@@ -28,7 +29,13 @@ void ListSettings::addOption()
     SettingsOption* qLine = new  SettingsOption(ui->listView);
     listElements->push_back(qLine);
     qLine->show();
+    connect(qLine->getButton(), &QPushButton::clicked, this, &ListSettings::optionErased);
 }
+
+
+
+
+
 void ListSettings::eraseOption(int index)
 {
     list<string>::iterator itr = data->begin();
@@ -65,7 +72,6 @@ void ListSettings::loadOptions()
         itr++;
         itr2++;
     }
-
 }
 
 void ListSettings::saveOptions()
@@ -74,4 +80,8 @@ void ListSettings::saveOptions()
     {
         data->push_back(element->getLineEdit()->text().toStdString());
     }
+    /*for (SettingsOption* option : *listElements) {
+        emit saveSettings(option);
+    }
+    */
 }

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -3,7 +3,7 @@
 
 #include <QPushButton>
 #include <QDialog>
-#include <QLineEdit>
+#include "widgets/editor/EditorTools/Settings/settingsoption.h"
 
 using namespace std;
 
@@ -36,7 +36,7 @@ private slots:
 private:
     Ui::ListSettings *ui;
     list<string> *data;
-    list<QLineEdit*> *listElements;
+    list<SettingsOption*> *listElements;
 };
 
 #endif // LISTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -1,11 +1,31 @@
 #ifndef LISTSETTINGS_H
 #define LISTSETTINGS_H
 
+#include <QPushButton>
+#include <QDialog>
 
-class ListSettings
+namespace Ui {
+class ListSettings;
+}
+
+class ListSettings : public QDialog
 {
+    Q_OBJECT
+
 public:
-    ListSettings();
+    explicit ListSettings(QWidget *parent = nullptr);
+    ~ListSettings();
+
+    // Buttons
+    QPushButton* getOK();
+    QPushButton* getCancel();
+
+signals:
+
+private slots:
+
+private:
+    Ui::ListSettings *ui;
 };
 
 #endif // LISTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -31,6 +31,7 @@ public:
 
 signals:
     void optionErased (int index);
+    void optionsSaved (string txt);
 
 private:
     Ui::ListSettings *ui;

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -3,6 +3,9 @@
 
 #include <QPushButton>
 #include <QDialog>
+#include <QLineEdit>
+
+using namespace std;
 
 namespace Ui {
 class ListSettings;
@@ -20,12 +23,20 @@ public:
     QPushButton* getOK();
     QPushButton* getCancel();
 
+    // List methods
+    void addOption();
+    void eraseOption(int index);
+    void saveOptions();
+    void loadOptions();
+
 signals:
 
 private slots:
 
 private:
     Ui::ListSettings *ui;
+    list<string> *data;
+    list<QLineEdit*> *listElements;
 };
 
 #endif // LISTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -1,0 +1,11 @@
+#ifndef LISTSETTINGS_H
+#define LISTSETTINGS_H
+
+
+class ListSettings
+{
+public:
+    ListSettings();
+};
+
+#endif // LISTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -27,13 +27,10 @@ public:
     void addOption();
     void eraseOption(int index);
     void loadOptions();
-    void saveSettings();
+    void saveOptions();
 
 signals:
     void optionErased (int index);
-
-public slots:
-    void saveOptions();
 
 private:
     Ui::ListSettings *ui;

--- a/widgets/editor/EditorTools/Settings/listsettings.h
+++ b/widgets/editor/EditorTools/Settings/listsettings.h
@@ -26,17 +26,20 @@ public:
     // List methods
     void addOption();
     void eraseOption(int index);
-    void saveOptions();
     void loadOptions();
+    void saveSettings();
 
 signals:
+    void optionErased (int index);
 
-private slots:
+public slots:
+    void saveOptions();
 
 private:
     Ui::ListSettings *ui;
     list<string> *data;
     list<SettingsOption*> *listElements;
+
 };
 
 #endif // LISTSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/listsettings.ui
+++ b/widgets/editor/EditorTools/Settings/listsettings.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ListSettings</class>
- <widget class="QDialog" name="ListSettings">
+ <widget class="ListSettings" name="ListSettings">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -66,6 +66,14 @@
    </property>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ListSettings</class>
+   <extends>QWidget</extends>
+   <header>listsettings.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -101,4 +109,8 @@
    </hints>
   </connection>
  </connections>
+ <slots>
+  <slot>accept()</slot>
+  <slot>reject()</slot>
+ </slots>
 </ui>

--- a/widgets/editor/EditorTools/Settings/listsettings.ui
+++ b/widgets/editor/EditorTools/Settings/listsettings.ui
@@ -52,6 +52,19 @@
     </rect>
    </property>
   </widget>
+  <widget class="QPushButton" name="Add">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>240</y>
+     <width>80</width>
+     <height>24</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Add</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/widgets/editor/EditorTools/Settings/listsettings.ui
+++ b/widgets/editor/EditorTools/Settings/listsettings.ui
@@ -29,6 +29,29 @@
     <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
    </property>
   </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>81</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>List Settings</string>
+   </property>
+  </widget>
+  <widget class="QListView" name="listView">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>40</y>
+     <width>351</width>
+     <height>192</height>
+    </rect>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/widgets/editor/EditorTools/Settings/listsettings.ui
+++ b/widgets/editor/EditorTools/Settings/listsettings.ui
@@ -42,16 +42,6 @@
     <string>List Settings</string>
    </property>
   </widget>
-  <widget class="QListView" name="listView">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>40</y>
-     <width>351</width>
-     <height>192</height>
-    </rect>
-   </property>
-  </widget>
   <widget class="QPushButton" name="Add">
    <property name="geometry">
     <rect>
@@ -64,6 +54,17 @@
    <property name="text">
     <string>Add</string>
    </property>
+  </widget>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>30</y>
+     <width>361</width>
+     <height>201</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="layout"/>
   </widget>
  </widget>
  <customwidgets>

--- a/widgets/editor/EditorTools/Settings/listsettings.ui
+++ b/widgets/editor/EditorTools/Settings/listsettings.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ListSettings</class>
+ <widget class="QDialog" name="ListSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>240</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ListSettings</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ListSettings</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/widgets/editor/EditorTools/Settings/presetsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/presetsettings.cpp
@@ -1,0 +1,6 @@
+#include "presetsettings.h"
+
+PresetSettings::PresetSettings()
+{
+
+}

--- a/widgets/editor/EditorTools/Settings/presetsettings.cpp
+++ b/widgets/editor/EditorTools/Settings/presetsettings.cpp
@@ -1,6 +1,15 @@
 #include "presetsettings.h"
+#include "ui_presetsettings.h"
 
-PresetSettings::PresetSettings()
+PresetSettings::PresetSettings(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::PresetSettings)
 {
-
+    ui->setupUi(this);
 }
+
+PresetSettings::~PresetSettings()
+{
+    delete ui;
+}
+

--- a/widgets/editor/EditorTools/Settings/presetsettings.h
+++ b/widgets/editor/EditorTools/Settings/presetsettings.h
@@ -1,0 +1,11 @@
+#ifndef PRESETSETTINGS_H
+#define PRESETSETTINGS_H
+
+
+class PresetSettings
+{
+public:
+    PresetSettings();
+};
+
+#endif // PRESETSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/presetsettings.h
+++ b/widgets/editor/EditorTools/Settings/presetsettings.h
@@ -1,11 +1,31 @@
 #ifndef PRESETSETTINGS_H
 #define PRESETSETTINGS_H
 
+#include <QPushButton>
+#include <QDialog>
 
-class PresetSettings
+namespace Ui {
+class PresetSettings;
+}
+
+class PresetSettings : public QDialog
 {
+    Q_OBJECT
+
 public:
-    PresetSettings();
+    explicit PresetSettings(QWidget *parent = nullptr);
+    ~PresetSettings();
+
+    // Buttons
+    QPushButton* getOK();
+    QPushButton* getCancel();
+
+signals:
+
+private slots:
+
+private:
+    Ui::PresetSettings *ui;
 };
 
 #endif // PRESETSETTINGS_H

--- a/widgets/editor/EditorTools/Settings/presetsettings.ui
+++ b/widgets/editor/EditorTools/Settings/presetsettings.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetSettings</class>
+ <widget class="QDialog" name="PresetSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>240</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PresetSettings</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PresetSettings</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/widgets/editor/EditorTools/Settings/settingsoption.cpp
+++ b/widgets/editor/EditorTools/Settings/settingsoption.cpp
@@ -1,17 +1,24 @@
 #include "settingsoption.h"
 #include "ui_settingsoption.h"
 
-SettingsOption::SettingsOption(QWidget *parent) :
+SettingsOption::SettingsOption(QWidget *parent, int index) :
     QWidget(parent),
     ui(new Ui::SettingsOption)
 {
     ui->setupUi(this);
+    this->index = index;
 }
 
 SettingsOption::~SettingsOption()
 {
     delete ui;
 }
+QPushButton* SettingsOption:: getButton(){
+    return ui->pushButton;
+}
+
+
+
 
  QLineEdit* SettingsOption::getLineEdit()
 {

--- a/widgets/editor/EditorTools/Settings/settingsoption.cpp
+++ b/widgets/editor/EditorTools/Settings/settingsoption.cpp
@@ -1,0 +1,19 @@
+#include "settingsoption.h"
+#include "ui_settingsoption.h"
+
+SettingsOption::SettingsOption(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::SettingsOption)
+{
+    ui->setupUi(this);
+}
+
+SettingsOption::~SettingsOption()
+{
+    delete ui;
+}
+
+ QLineEdit* SettingsOption::getLineEdit()
+{
+    return ui->lineEdit;
+}

--- a/widgets/editor/EditorTools/Settings/settingsoption.cpp
+++ b/widgets/editor/EditorTools/Settings/settingsoption.cpp
@@ -12,22 +12,31 @@ SettingsOption::SettingsOption(QWidget *parent, int index, ListSettings* listPar
     this->listParent = listParent;
 }
 
+SettingsOption::~SettingsOption()
+{
+    delete ui;
+}
+
+
+int SettingsOption::getIndex()
+{
+    return index;
+}
+
+void SettingsOption::setIndex(int value)
+{
+    index = value;
+}
+
 void SettingsOption::erase()
 {
     if (listParent != nullptr)
         emit listParent->optionErased(index);
 }
 
-SettingsOption::~SettingsOption()
-{
-    delete ui;
-}
 QPushButton* SettingsOption:: getButton(){
     return ui->pushButton;
 }
-
-
-
 
  QLineEdit* SettingsOption::getLineEdit()
 {

--- a/widgets/editor/EditorTools/Settings/settingsoption.cpp
+++ b/widgets/editor/EditorTools/Settings/settingsoption.cpp
@@ -1,12 +1,21 @@
 #include "settingsoption.h"
 #include "ui_settingsoption.h"
 
-SettingsOption::SettingsOption(QWidget *parent, int index) :
+#include "widgets/editor/EditorTools/Settings/listsettings.h"
+
+SettingsOption::SettingsOption(QWidget *parent, int index, ListSettings* listParent) :
     QWidget(parent),
     ui(new Ui::SettingsOption)
 {
     ui->setupUi(this);
     this->index = index;
+    this->listParent = listParent;
+}
+
+void SettingsOption::erase()
+{
+    if (listParent != nullptr)
+        emit listParent->optionErased(index);
 }
 
 SettingsOption::~SettingsOption()

--- a/widgets/editor/EditorTools/Settings/settingsoption.h
+++ b/widgets/editor/EditorTools/Settings/settingsoption.h
@@ -1,0 +1,24 @@
+#ifndef SETTINGSOPTION_H
+#define SETTINGSOPTION_H
+#include <QLineEdit>
+#include <QWidget>
+
+namespace Ui {
+class SettingsOption;
+}
+
+class SettingsOption : public QWidget
+{
+    Q_OBJECT
+
+public:
+    //make a fucntion to access Qline
+    explicit SettingsOption(QWidget *parent = nullptr);
+    ~SettingsOption();
+   QLineEdit* getLineEdit();
+
+private:
+    Ui::SettingsOption *ui;
+};
+
+#endif // SETTINGSOPTION_H

--- a/widgets/editor/EditorTools/Settings/settingsoption.h
+++ b/widgets/editor/EditorTools/Settings/settingsoption.h
@@ -20,6 +20,8 @@ public:
     ~SettingsOption();
     QLineEdit* getLineEdit();
     QPushButton* getButton();
+    int getIndex();
+    void setIndex(int value);
     void erase();
 
 private:

--- a/widgets/editor/EditorTools/Settings/settingsoption.h
+++ b/widgets/editor/EditorTools/Settings/settingsoption.h
@@ -2,6 +2,7 @@
 #define SETTINGSOPTION_H
 #include <QLineEdit>
 #include <QWidget>
+#include <QPushButton>
 
 namespace Ui {
 class SettingsOption;
@@ -13,12 +14,14 @@ class SettingsOption : public QWidget
 
 public:
     //make a fucntion to access Qline
-    explicit SettingsOption(QWidget *parent = nullptr);
+    explicit SettingsOption(QWidget *parent = nullptr, int index = 0);
     ~SettingsOption();
-   QLineEdit* getLineEdit();
+    QLineEdit* getLineEdit();
+    QPushButton* getButton();
 
 private:
     Ui::SettingsOption *ui;
+    int index;
 };
 
 #endif // SETTINGSOPTION_H

--- a/widgets/editor/EditorTools/Settings/settingsoption.h
+++ b/widgets/editor/EditorTools/Settings/settingsoption.h
@@ -4,6 +4,8 @@
 #include <QWidget>
 #include <QPushButton>
 
+class ListSettings;
+
 namespace Ui {
 class SettingsOption;
 }
@@ -14,13 +16,15 @@ class SettingsOption : public QWidget
 
 public:
     //make a fucntion to access Qline
-    explicit SettingsOption(QWidget *parent = nullptr, int index = 0);
+    explicit SettingsOption(QWidget *parent = nullptr, int index = 0, ListSettings *listParent = nullptr);
     ~SettingsOption();
     QLineEdit* getLineEdit();
     QPushButton* getButton();
+    void erase();
 
 private:
     Ui::SettingsOption *ui;
+    ListSettings* listParent;
     int index;
 };
 

--- a/widgets/editor/EditorTools/Settings/settingsoption.ui
+++ b/widgets/editor/EditorTools/Settings/settingsoption.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsOption</class>
+ <widget class="QWidget" name="SettingsOption">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>601</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QLineEdit" name="lineEdit">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>30</y>
+     <width>91</width>
+     <height>16</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButton">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>30</y>
+     <width>31</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>PushButton</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/widgets/editor/EditorTools/Settings/settingsoption.ui
+++ b/widgets/editor/EditorTools/Settings/settingsoption.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>601</width>
-    <height>300</height>
+    <width>203</width>
+    <height>37</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,8 +17,8 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>30</y>
-     <width>91</width>
+     <y>10</y>
+     <width>131</width>
      <height>16</height>
     </rect>
    </property>
@@ -26,14 +26,14 @@
   <widget class="QPushButton" name="pushButton">
    <property name="geometry">
     <rect>
-     <x>110</x>
-     <y>30</y>
-     <width>31</width>
+     <x>150</x>
+     <y>10</y>
+     <width>41</width>
      <height>16</height>
     </rect>
    </property>
    <property name="text">
-    <string>PushButton</string>
+    <string>Delete</string>
    </property>
   </widget>
  </widget>

--- a/widgets/editor/EditorTools/editortools.cpp
+++ b/widgets/editor/EditorTools/editortools.cpp
@@ -6,11 +6,22 @@ EditorTools::EditorTools(QWidget *parent) :
     ui(new Ui::EditorTools)
 {
     ui->setupUi(this);
+    // set up the settings pages
+    effectSettings = new EffectSettings(this);
+    listSettings = new ListSettings(this);
+    presetSettings = new PresetSettings(this);
+    // connect the buttons to show the settings pages
+    connect(getEffectSettings(), &QAbstractButton::clicked, this, &EditorTools::openEffectSettings);
+    connect(getPresetSettings(), &QAbstractButton::clicked, this, &EditorTools::openPresetSettings);
+    connect(getFieldSettings(), &QAbstractButton::clicked, this, &EditorTools::openListSettings);
 }
 
 EditorTools::~EditorTools()
 {
     delete ui;
+    delete effectSettings;
+    delete listSettings;
+    delete presetSettings;
 }
 
 // Clipboard
@@ -48,3 +59,8 @@ QPushButton* EditorTools::getPreset4() { return ui->preset4; }
 QPushButton* EditorTools::getAddPreset() { return ui->addPreset; }
 QPushButton* EditorTools::getMorePresets() { return ui->morePresets; }
 QPushButton* EditorTools::getPresetSettings() { return ui->presetSettings; }
+
+// Methods
+void EditorTools::openEffectSettings() { effectSettings->open(); }
+void EditorTools::openListSettings() { listSettings->open(); }
+void EditorTools::openPresetSettings() { presetSettings->open(); }

--- a/widgets/editor/EditorTools/editortools.cpp
+++ b/widgets/editor/EditorTools/editortools.cpp
@@ -62,5 +62,6 @@ QPushButton* EditorTools::getPresetSettings() { return ui->presetSettings; }
 
 // Methods
 void EditorTools::openEffectSettings() { effectSettings->open(); }
-void EditorTools::openListSettings() { listSettings->open(); }
+void EditorTools::openListSettings() { listSettings->open();
+    listSettings->loadOptions();}
 void EditorTools::openPresetSettings() { presetSettings->open(); }

--- a/widgets/editor/EditorTools/editortools.cpp
+++ b/widgets/editor/EditorTools/editortools.cpp
@@ -60,6 +60,11 @@ QPushButton* EditorTools::getAddPreset() { return ui->addPreset; }
 QPushButton* EditorTools::getMorePresets() { return ui->morePresets; }
 QPushButton* EditorTools::getPresetSettings() { return ui->presetSettings; }
 
+// Settings Pages
+EffectSettings* EditorTools::getEffectSettingsPage() { return effectSettings; }
+ListSettings* EditorTools::getListSettingsPage() { return listSettings; }
+PresetSettings* EditorTools::getPresetSettingsPage() { return presetSettings; }
+
 // Methods
 void EditorTools::openEffectSettings() { effectSettings->open(); }
 void EditorTools::openListSettings() { listSettings->open();

--- a/widgets/editor/EditorTools/editortools.h
+++ b/widgets/editor/EditorTools/editortools.h
@@ -55,6 +55,11 @@ public:
     QPushButton* getMorePresets();
     QPushButton* getPresetSettings();
 
+    // Settings Pages
+    EffectSettings* getEffectSettingsPage();
+    ListSettings* getListSettingsPage();
+    PresetSettings* getPresetSettingsPage();
+
     // Methods
     void openEffectSettings();
     void openListSettings();
@@ -62,6 +67,7 @@ public:
 
 signals:
     void characterEffectRequested(int effectNumber);
+    void listFieldUpdateRequested(string txt);
 
 
 private slots:

--- a/widgets/editor/EditorTools/editortools.h
+++ b/widgets/editor/EditorTools/editortools.h
@@ -3,6 +3,9 @@
 
 #include <QPushButton>
 #include <QWidget>
+#include "Settings/effectsettings.h"
+#include "Settings/listsettings.h"
+#include "Settings/presetsettings.h"
 
 namespace Ui {
 class EditorTools;
@@ -52,6 +55,11 @@ public:
     QPushButton* getMorePresets();
     QPushButton* getPresetSettings();
 
+    // Methods
+    void openEffectSettings();
+    void openListSettings();
+    void openPresetSettings();
+
 signals:
     void characterEffectRequested(int effectNumber);
 
@@ -60,6 +68,9 @@ private slots:
 
 private:
     Ui::EditorTools *ui;
+    EffectSettings *effectSettings;
+    ListSettings *listSettings;
+    PresetSettings *presetSettings;
 };
 
 #endif // EDITORTOOLS_H

--- a/widgets/editor/Fields/ListField/listfield.cpp
+++ b/widgets/editor/Fields/ListField/listfield.cpp
@@ -1,0 +1,247 @@
+#include "listfield.h"
+#include "ui_listfield.h"
+#include "widgets/editor/Fields/CharacterField//characterfield.h"
+
+ListField::ListField(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ListField)
+{
+    ui->setupUi(this);
+    connect(ui->remove, &QAbstractButton::clicked, this, &ListField::sendRemove);
+    connect(ui->addCharacter, &QAbstractButton::clicked, this, &ListField::onCharacterClicked);
+    connect(ui->preview, &QPushButton::clicked, this, &ListField::exportToBrowser);
+    //connect(editorTools, &EditorTools::characterEffectRequested, this, &TextField::applyCharacterEffect);
+    connect(this, &ListField::updateRequested, this, &ListField::updateUI);
+}
+
+void ListField::onCharacterClicked() {
+    if (characterFieldAdded) {
+        // If already added, remove the widget
+        removeCharacterWidget();
+    } else {
+        addCharacterWidget();
+    }
+
+    // Toggle the state
+    characterFieldAdded = !characterFieldAdded;
+}
+
+void ListField::removeCharacterWidget() {
+    if (characterField) {
+        ui->AboveFieldLayout->removeWidget(characterField);
+        delete characterField;
+        characterField = nullptr;
+    }
+}
+
+
+void ListField::addCharacterWidget() {
+    characterField = new CharacterField(this);
+    ui->AboveFieldLayout->addWidget(characterField);
+}
+
+
+QString ListField::generateHtml(const QString& content) {
+    QString base64Image;
+    QString fullHtml;
+    fullHtml += "<!DOCTYPE html>";
+    fullHtml += "<html><head><title>Dialogue Preview</title>";
+    fullHtml += R"(<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>)";
+    fullHtml += R"(
+        <script>
+        $(document).ready(function() {
+               applyEffectsFromTags();
+        });
+
+        function applyEffectsFromTags() {
+            // Check for the 'wobble' effect
+            $('effect[type="wobble"]').each(function() {
+                let content = $(this).text();
+                $(this).replaceWith('<span class="wobbled">' + content + '</span>');
+            });
+
+            // Check for the 'enlarge' effect
+            $('effect[type="enlarge"]').each(function() {
+                let content = $(this).text();
+                $(this).replaceWith('<span class="enlarged">' + content + '</span>');
+            });
+
+            // Check for the 'speedUp' effect
+            $('effect[type="speedUp"]').each(function() {
+                let content = $(this).text();
+                let wrappedContent = '';
+                let delay = 1;
+                let delayIncrement = 0.2;
+
+                for(let i = 0; i < content.length; i++) {
+                    let char = content[i] === ' ' ? '&nbsp;' : content[i];  // Replace space with &nbsp;
+                    wrappedContent += '<span style="animation-delay:' + delay + 's">' + char + '</span>';
+                    delay += delayIncrement;
+                }
+
+                $(this).replaceWith('<span class="sped-up">' + wrappedContent + '</span>');
+            });
+
+            $('effect[type="typed"]').each(function() {
+                let content = $(this).text();
+                let wrappedContent = '';
+                let delay = 1;
+                let delayIncrement = 0.2;
+
+                for(let i = 0; i < content.length; i++) {
+                    let char = content[i] === ' ' ? '&nbsp;' : content[i];  // Replace space with &nbsp;
+                    wrappedContent += '<span style="animation-delay:' + delay + 's">' + char + '</span>';
+                    delay += delayIncrement;
+                }
+
+                $(this).replaceWith('<span class="typed">' + wrappedContent + '</span>');
+            });
+
+            // Check for 'bold' effect
+            $('effect[type="bold"]').each(function() {
+                let content = $(this).text();
+                $(this).replaceWith('<span class="bold">' + content + '</span>');
+            });
+        }
+        </script>
+
+        <style>
+        .enlarged { font-size: 150%; }
+        @keyframes shake {
+            0%, 100% { transform: translateX(0); }
+            10%, 30%, 50%, 70%, 90% { transform: translateX(-10px); }
+            20%, 40%, 60%, 80% { transform: translateX(10px); }
+        }
+
+        .wobbled {
+            display: inline-block;
+            animation: shake 0.5s infinite;
+        }
+
+        @keyframes flyInCharacter {
+            0% { transform: translateY(100%); opacity: 0; }
+            70% { transform: translateY(0); opacity: 1; }
+            100% { transform: translateY(0); opacity: 1; }
+        }
+
+        .sped-up span {
+            display: inline-block;  /* makes spans sit side-by-side */
+            animation: flyInCharacter 2s infinite;  /* Adjust time for how long you want the animation to last */
+            transform: translateY(100%);
+            opacity: 0;
+        }
+
+        @keyframes typing {
+          from {opacity: 0;}
+          to {opacity: 1;}
+        }
+
+        .typed span {
+            opacity: 0;
+            overflow: hidden;
+            display: inline-block;
+            animation: typing 0.05s forwards;
+        }
+
+        @keyframes bolden {
+          0%, 80%, 100% {font-weight: 300;}
+          20% {transition: font-weight 500ms ease-in-out; font-weight: 900;}
+        }
+
+        .bold {
+            display: inline-block;
+            animation: bolden 1.5s infinite;
+        }
+
+        </style>
+    )";
+
+    fullHtml += R"(
+    <style>
+        body {
+            background-image: url('data:image/jpg;base64,)" + base64Image + R"(');
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center center;
+            font-family: Arial, sans-serif;
+            height: 100vh;
+            margin: 0;  // Ensure no default margins
+            overflow: hidden; // Hide any overflow content
+        }
+
+        .dialogue-box {
+            position: absolute;
+            top: 0;
+            left: 0;
+            background: #ECEFF1;
+            border-radius: 100px;
+            padding: 1rem;
+            width: 390px;
+            height: 160px;
+            box-shadow: 10px 10px rgba(0,0,0,0.2);
+            font-size: 24px;
+        }
+    </style>
+    )";
+
+    fullHtml += "</head><body>";
+    fullHtml += "<div class='dialogue-box'>" + content + "</div>";
+    fullHtml += "</body></html>";
+
+    return fullHtml;
+}
+
+void ListField::applyCharacterEffect(int effectNumber) {
+    //    if(effectNumber == 1) {
+    //        view->page()->runJavaScript("enlargeCharacter();");
+    //    }
+    //    else if(effectNumber == 2) {
+    //        view->page()->runJavaScript("wobbleCharacter();");
+    //    }
+    //    else if(effectNumber == 3) {
+    //        view->page()->runJavaScript("speedUpText();");
+    //    }
+}
+
+
+void ListField::exportToBrowser() {
+    QString content = QString::fromStdString(data->getText());
+    emit previewRequested(content);
+}
+
+ListField::~ListField()
+{
+    delete ui;
+}
+
+QComboBox* ListField::getComboBox() {
+    return ui->comboBox;
+}
+
+QPushButton* ListField::getPreview() {
+    return ui->preview;
+}
+
+ListData* ListField::getData() {
+    return data;
+}
+
+void ListField::setData(ListData* data) {
+    this->data = data;
+}
+
+void ListField::sendRemove() {
+    emit removeField(this);
+}
+
+void ListField::updateUI()
+{
+    // clear the options
+    ui->comboBox->clear();
+    // add the options
+    list<string> dataOptions = data->toList();
+    for(string s : dataOptions)
+    {
+        ui->comboBox->addItem(QString::fromStdString(s));
+    }
+}

--- a/widgets/editor/Fields/ListField/listfield.cpp
+++ b/widgets/editor/Fields/ListField/listfield.cpp
@@ -41,9 +41,58 @@ void ListField::addCharacterWidget() {
 }
 
 
-QString ListField::generateHtml(const QString& content) {
+QString ListField::generateHtml(const QString& content, const QString& content2, ListData* textData) {
+
+    QString newContent = content;
+    // 1 = wobble
+    if (textData->hasFieldEffect(1))
+        newContent = "<effect type=\"wobble\">" + content + "</effect>";
+    // 2 = enlarge
+    else if (textData->hasFieldEffect(2))
+        newContent = "<effect type=\"enlarge\">" + content + "</effect>";
+    // 3 = speedUp
+    else if (textData->hasFieldEffect(3))
+        newContent = "<effect type=\"speedUp\">" + content + "</effect>";
+    // 4 = bold
+    else if (textData->hasFieldEffect(4))
+        newContent = "<effect type=\"bold\">" + content + "</effect>";
+    // 5 = typed
+    else if (textData->hasFieldEffect(5))
+        newContent = "<effect type=\"typed\">" + content + "</effect>";
+
+    if (newContent == content)
+    {
+        const map<pair<int,int>, list<int>> textEffects = textData->getTextEffects();
+        int totalAddedChars = 0;
+        for(map<pair<int,int>,list<int>>::const_iterator it = textEffects.begin(); it != textEffects.end(); it++)
+        {
+            int start = it->first.first;
+            int end = it->first.second;
+            int tag = it->second.front();
+
+            QString string1 = "";
+            QString string2 = "</effect>";
+            if (tag == 1)
+                string1 = "<effect type=\"wobble\">";
+            else if (tag == 2)
+                string1 = "<effect type=\"enlarge\">";
+            else if (tag == 3)
+                string1 = "<effect type=\"speedUp\">";
+            else if (tag == 4)
+                string1 = "<effect type=\"bold\">";
+            else if (tag == 5)
+                string1 = "<effect type=\"typed\">";
+
+            newContent.insert(start + totalAddedChars, string1);
+            totalAddedChars += string1.length();
+            newContent.insert(end + totalAddedChars,string2);
+            totalAddedChars += string2.length();
+        }
+    }
+
     QString base64Image;
     QString fullHtml;
+
     fullHtml += "<!DOCTYPE html>";
     fullHtml += "<html><head><title>Dialogue Preview</title>";
     fullHtml += R"(<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>)";
@@ -169,23 +218,49 @@ QString ListField::generateHtml(const QString& content) {
             overflow: hidden; // Hide any overflow content
         }
 
+        .dialogue-container {
+            position: relative;
+            width: 100%;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: top;
+            align-items: left;
+        }
+
         .dialogue-box {
-            position: absolute;
-            top: 0;
-            left: 0;
             background: #ECEFF1;
-            border-radius: 100px;
+            border-radius: 15px;
             padding: 1rem;
             width: 390px;
             height: 160px;
             box-shadow: 10px 10px rgba(0,0,0,0.2);
             font-size: 24px;
+            margin-top: 10px;
         }
+
+        .character-box {
+            background: #ECEFF1;
+            border-radius: 15px;
+            padding: 1rem;
+            width: 300px; /* Adjust width as necessary */
+            height: 20px; /* Adjust height as necessary */
+            box-shadow: 10px 10px rgba(0,0,0,0.2);
+            font-size: 24px;
+            z-index: 2;
+        }
+
+
     </style>
     )";
 
+    // ... (The rest of your styles remain the same)
+
     fullHtml += "</head><body>";
-    fullHtml += "<div class='dialogue-box'>" + content + "</div>";
+    fullHtml += R"(<div class='dialogue-container'>)"; // This wraps both boxes
+    if (content2 != "") fullHtml += R"(<div class='character-box'>)" + content2 + R"(</div>)";
+    fullHtml += R"(<div class='dialogue-box'>)" + newContent + R"(</div>)";
+    fullHtml += R"(</div>)"; // Close .dialogue-container
     fullHtml += "</body></html>";
 
     return fullHtml;
@@ -206,7 +281,11 @@ void ListField::applyCharacterEffect(int effectNumber) {
 
 void ListField::exportToBrowser() {
     QString content = QString::fromStdString(data->getText());
-    emit previewRequested(content);
+    QString content2;
+    if (characterField){
+        content2 = characterField->getText();
+    }
+    emit previewRequested(content, content2, data);
 }
 
 ListField::~ListField()

--- a/widgets/editor/Fields/ListField/listfield.h
+++ b/widgets/editor/Fields/ListField/listfield.h
@@ -19,7 +19,7 @@ class ListField : public QWidget
 public:
     explicit ListField(QWidget *parent = nullptr);
     ~ListField();
-    static QString generateHtml(const QString& content);
+    static QString generateHtml(const QString& content, const QString& content2, ListData* textData);
     void exportToBrowser();
     void applyCharacterEffect(int effectNumber);
     void setView(QWebEngineView* v);
@@ -35,7 +35,7 @@ public:
     void updateUI();
 
 signals:
-    void previewRequested(const QString& content);
+    void previewRequested(const QString& content,const QString& content2, ListData* textData);
     void removeField(ListField* field);
     void updateRequested();
 

--- a/widgets/editor/Fields/ListField/listfield.h
+++ b/widgets/editor/Fields/ListField/listfield.h
@@ -1,0 +1,50 @@
+#ifndef LISTFIELD_H
+#define LISTFIELD_H
+
+#include "data/Fields/MainFields/list/listdata.h"
+#include <QLineEdit>
+#include <QPushButton>
+#include <QWidget>
+#include <QWebEngineView>
+
+class CharacterField;
+namespace Ui {
+class ListField;
+}
+
+class ListField : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ListField(QWidget *parent = nullptr);
+    ~ListField();
+    static QString generateHtml(const QString& content);
+    void exportToBrowser();
+    void applyCharacterEffect(int effectNumber);
+    void setView(QWebEngineView* v);
+
+    QComboBox* getComboBox();
+    QPushButton* getPreview();
+
+    ListData* getData();
+    void setData(ListData* data);
+    void onCharacterClicked();
+    void addCharacterWidget();
+    void removeCharacterWidget();
+    void updateUI();
+
+signals:
+    void previewRequested(const QString& content);
+    void removeField(ListField* field);
+    void updateRequested();
+
+
+private:
+    Ui::ListField *ui;
+    ListData* data = nullptr;
+    bool characterFieldAdded = false;
+    CharacterField* characterField = nullptr;
+    void sendRemove();
+};
+#endif // LISTFIELD_H

--- a/widgets/editor/Fields/ListField/listfield.ui
+++ b/widgets/editor/Fields/ListField/listfield.ui
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ListField</class>
+ <widget class="QWidget" name="ListField">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>970</width>
+    <height>232</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>1</horstretch>
+    <verstretch>1</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>230</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>970</width>
+    <height>232</height>
+   </size>
+  </property>
+  <property name="baseSize">
+   <size>
+    <width>970</width>
+    <height>230</height>
+   </size>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>18</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="AboveFieldLayout"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QWidget" name="InnerTextField" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLineEdit {
+	border-radius: 5px;
+	background-color:white;
+}</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="horizontalSpacing">
+       <number>15</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="preview">
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normalon>:/rec/img/icons/preview.png</normalon>
+         </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" rowspan="2">
+       <widget class="QComboBox" name="comboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>194</width>
+          <height>46</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>970</width>
+          <height>230</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>18</pointsize>
+         </font>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QPushButton" name="remove">
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normalon>:/rec/img/icons/remove.png</normalon>
+         </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="addCharacter">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../../Resources.qrc">
+            <normaloff>:/rec/img/icons/character.png</normaloff>:/rec/img/icons/character.png</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>32</width>
+            <height>32</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../../Resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/widgets/editor/MainEditor/maineditor.cpp
+++ b/widgets/editor/MainEditor/maineditor.cpp
@@ -262,6 +262,9 @@ void MainEditor::createListField() {
     // field is removed when the remove button is clicked within the UI.
     connect(listField, &ListField::removeField, this, &MainEditor::removeListField);
     connect(listField, &ListField::previewRequested, this, &MainEditor::handlePreviewRequest);
+
+    // update the list settings
+    editorTools->getListSettingsPage()->saveOptions();
 }
 
 void MainEditor::removeHead() {

--- a/widgets/editor/MainEditor/maineditor.cpp
+++ b/widgets/editor/MainEditor/maineditor.cpp
@@ -9,6 +9,8 @@
 #include <QWebEngineView>
 
 #include "data/Fields/MainFields/text/textdata.h"
+#include "widgets/editor/Fields/ListField/listfield.h"
+#include "data/Fields/MainFields/list/listdata.h"
 
 MainEditor::MainEditor(QWidget *parent) :
     QMainWindow(parent),
@@ -24,7 +26,9 @@ MainEditor::MainEditor(QWidget *parent) :
     connect(editorTools->getCopy(), &QAbstractButton::clicked, this, &MainEditor::on_actionCopy_triggered);
 
     connect(editorTools->getTextField(), &QAbstractButton::clicked, this, &MainEditor::createTextField);
-    connect(editorTools->getCustomField1(), &QAbstractButton::clicked, this, &MainEditor::removeHead);
+    connect(editorTools->getCustomField1(), &QAbstractButton::clicked, this, &MainEditor::createListField);
+
+    connect(editorTools->getListSettingsPage(), &ListSettings::optionsSaved, this, &MainEditor::updateListFields);
 
     connect(designer->getCreateField(), &QAbstractButton::clicked, this, &MainEditor::createTextField);
 
@@ -224,6 +228,42 @@ void MainEditor::createTextField() {
     connect(textField, &TextField::previewRequested, this, &MainEditor::handlePreviewRequest);
 }
 
+void MainEditor::createListField() {
+    // Create a new head pointer if the data is currently null.
+    if (!data) {
+        ListField* listField = designer->createListField();
+        data = new ListData(listField, nullptr, nullptr);
+
+        // Connect the removeField signal to the MainEditor's removeField function so that the
+        // field is removed when the remove button is clicked within the UI.
+        connect(listField, &ListField::removeField, this, &MainEditor::removeListField);
+        connect(listField, &ListField::previewRequested, this, &MainEditor::handlePreviewRequest);
+        return;
+    }
+
+    // Add a new text field with a connection if a head pointer (data) exists
+    FieldData* last = data;
+    while(last->getToConnection() != nullptr && last->getToConnection()->getNext() != nullptr) {
+        last = last->getToConnection()->getNext();
+    }
+
+    // Create a new field connection (UI)
+    FieldConnection* fieldConnection = designer->createFieldConnection();
+    // Create a new text field (UI)
+    ListField* listField = designer->createListField();
+    ListData* newList = new ListData(listField, nullptr, nullptr);
+
+    // Create a connection
+    ConnectionData* connection = new ConnectionData(fieldConnection, last, newList);
+    last->replaceToConnection(connection);
+    newList->replaceFromConnection(connection);
+
+    // Connect the removeField signal to the MainEditor's removeField function so that the
+    // field is removed when the remove button is clicked within the UI.
+    connect(listField, &ListField::removeField, this, &MainEditor::removeListField);
+    connect(listField, &ListField::previewRequested, this, &MainEditor::handlePreviewRequest);
+}
+
 void MainEditor::removeHead() {
     if (data == nullptr) return;
 
@@ -298,4 +338,80 @@ void MainEditor::removeField(TextField* field) {
     designer->removeWidget(field);
     delete fieldData;
     
+}
+
+// TODO: THIS HAS THE SAME BODY AS THE ABOVE FUNCTION WITH A DIFFERENT ARG TYPE
+// WE SHOULD MAKE ALL FIELDS INHERIT FROM A BASE FIELD
+// THEN WE ONLY NEED ONE removeFieldFunction ***
+void MainEditor::removeListField(ListField* field) {
+    FieldData* fieldData = field->getData();
+    ConnectionData* fromConnection = fieldData->getFromConnection();
+    ConnectionData* toConnection = fieldData->getToConnection();
+
+    // STEP 1) Reconfigure connections to remove references to fieldData
+
+    // Modify the head if the field is the current head of the data field container
+    // The fromConnection is maintained while the toConnection is removed.
+    if (!fromConnection) {
+        if (fieldData != data) {
+            qWarning("This field is part of a detatched head.");
+            return;
+        }
+
+        // Assign a new head
+        if (toConnection) {
+            data = toConnection->getNext();
+            data->replaceFromConnection(nullptr);
+        }
+        else data = nullptr;
+    }
+
+    // Re-assign the fromConnection
+    else if (fromConnection) {
+        if (toConnection) {
+            fromConnection->replaceNext(toConnection->getNext());
+            toConnection->getNext()->replaceFromConnection(fromConnection);
+        }
+        else {
+            // REMOVE FROM CONNECTION
+            fromConnection->getPrevious()->replaceToConnection(nullptr);
+
+            designer->removeWidget(fromConnection->getUi());
+            delete fromConnection;
+        }
+    }
+
+    // Remove the toConnection
+    if (toConnection) {
+        designer->removeWidget(toConnection->getUi());
+        delete toConnection;
+    }
+
+    // STEP 2) Cleanup and free memory
+    designer->removeWidget(field);
+    delete fieldData;
+}
+
+void MainEditor::updateListFields(string txt)
+{
+    qDebug() << "Main Editor: Updating List Fields with : " << txt;
+    // Update fields from head onward
+    FieldData* currData = data;
+    while (currData != nullptr)
+    {
+        qDebug() << "Looking at field with ID = " << currData->getID();
+        // check to see if this is a list field
+        if (currData->getID() == 2)
+        {
+            qDebug() << "Main Editor: Updating a field";
+            ((ListData*)currData)->setDelimiterAndText(baseDelimiter, txt);
+            emit ((ListField*)((ListData*)currData)->getUi())->updateRequested();
+        }
+        // Look for more fields
+        ConnectionData* toData = currData->getToConnection();
+        if (toData != nullptr)
+            currData = toData->getNext();
+        else
+            currData = nullptr;
+    }
 }

--- a/widgets/editor/MainEditor/maineditor.cpp
+++ b/widgets/editor/MainEditor/maineditor.cpp
@@ -11,10 +11,7 @@
 #include <QDebug>
 #include <qclipboard.h>
 
-#include "data/Fields/MainFields/text/textdata.h"
 #include "widgets/editor/Fields/ListField/listfield.h"
-#include "data/Fields/MainFields/list/listdata.h"
-
 
 MainEditor::MainEditor(QWidget *parent) :
     QMainWindow(parent),
@@ -83,8 +80,12 @@ MainEditor::MainEditor(QWidget *parent) :
 }
 
 
-void MainEditor::handlePreviewRequest(const QString& content, const QString& content2, TextData* textData) {
-    QString fullHtml = TextField::generateHtml(content, content2, textData);
+void MainEditor::handlePreviewRequest(const QString& content, const QString& content2, FieldData* textData) {
+    QString fullHtml;
+    if (data->getID() == 1)
+        fullHtml = TextField::generateHtml(content, content2, (TextData*) textData);
+    else if (data->getID() == 2)
+        fullHtml = ListField::generateHtml(content, content2, (ListData*) textData);
     QWebEngineView* view = designer->getPreview();
     view->setHtml(fullHtml);
     view->show();
@@ -616,6 +617,7 @@ void MainEditor::updateListFields(string txt)
         else
             currData = nullptr;
     }
+}
 
 // Gets active text field
 // If no active text field, return most recent active text field
@@ -639,6 +641,7 @@ FieldData* MainEditor::getActiveField()
     lastActive = currentField;
     return currentField;
 }
+
 
 void MainEditor::preset_createTextField() {
     createTextField();
@@ -670,5 +673,4 @@ void MainEditor::createPreset() {
 
 void MainEditor::applyPreset(Preset* preset) {
     preset->apply(data, this);
-
 }

--- a/widgets/editor/MainEditor/maineditor.h
+++ b/widgets/editor/MainEditor/maineditor.h
@@ -1,14 +1,10 @@
 #ifndef MAINEDITOR_H
 #define MAINEDITOR_H
 
-#include "data/ConnectionData/connectiondata.h"
 #include "widgets/editor/Designer/designer.h"
 #include "widgets/editor/EditorTools/editortools.h"
-#include "data/Fields/MainFields/list/listdata.h"
 #include "data/Fields/fielddata.h"
-#include "data/Fields/MainFields/text/textdata.h"
 #include <QMainWindow>
-#include <typeinfo>
 
 namespace Ui {
 class MainEditor;
@@ -21,7 +17,6 @@ class MainEditor : public QMainWindow
 public:
     explicit MainEditor(QWidget *parent = nullptr);
     ~MainEditor();
-signals:
 
     void preset_createTextField();
     void preset_createTextFieldAndCharacter();
@@ -67,7 +62,7 @@ private slots:
     /**
      * Creates a text field and adds it to the UI
     */
-    void handlePreviewRequest(const QString& content, const QString& content2, TextData* textData);
+    void handlePreviewRequest(const QString& content, const QString& content2, FieldData* textData);
     void createTextField();
     void createListField();
 

--- a/widgets/editor/MainEditor/maineditor.h
+++ b/widgets/editor/MainEditor/maineditor.h
@@ -1,10 +1,12 @@
 #ifndef MAINEDITOR_H
 #define MAINEDITOR_H
 
+#include "data/ConnectionData/connectiondata.h"
 #include "widgets/editor/Designer/designer.h"
 #include "widgets/editor/EditorTools/editortools.h"
-#include "data/Fields/fielddata.h"
+#include "data/Fields/MainFields/list/listdata.h"
 #include <QMainWindow>
+#include <typeinfo>
 
 namespace Ui {
 class MainEditor;
@@ -17,6 +19,7 @@ class MainEditor : public QMainWindow
 public:
     explicit MainEditor(QWidget *parent = nullptr);
     ~MainEditor();
+signals:
 
 private slots:
     void on_actionOpen_triggered();
@@ -37,6 +40,7 @@ private slots:
     */
     void handlePreviewRequest(const QString& content);
     void createTextField();
+    void createListField();
 
     /**
      * Removes the head of the data (field container)
@@ -49,6 +53,13 @@ private slots:
      * @param field - The ui field to remove
     */
     void removeField(TextField* field);
+    void removeListField(ListField* field);
+
+    /**
+     * @brief updateListFields
+     * @param options
+     */
+    void updateListFields(string txt);
 
 private:
     Ui::MainEditor *ui = nullptr;


### PR DESCRIPTION
Created 4 new classes
- EffectSettings
- ListSettings
- PresetSettings
- SettingsOption
- ListField
Each settings page opens from a button in EditorTools.
Effect and Preset settings are blank QDialogs.
ListSettings has a list of SettingsOptions* that can be edited.
Edits will stay when the menu is closed and re-opened.

ListField is the UI widget that holds ListData.
It can be added, removed, hold a character field, be previewed.
When the settings are updated, it updates each ListField.

Additionally, there is now a virtual getID() function in FieldData that returns the ID of the field type:
FieldData = 0
TextData = 1
ListData = 2
InputData = 3